### PR TITLE
Remove duplicated XSAppIconAssets entry from Info.plist for MacCatalyst

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist
@@ -28,7 +28,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
 </dict>
 </plist>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MacCatalyst/Info.plist
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MacCatalyst/Info.plist
@@ -28,7 +28,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
 </dict>
 </plist>


### PR DESCRIPTION
ref: https://github.com/dotnet/maui/pull/1270

Info.plist for MacCatalyst already has XSAppIconAssets entry, so I deleted one.

```sh
$ plutil -lint src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist
src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist: OK
$ plutil -p src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist
{
  "LSMinimumSystemVersion" => "10.15"
  "UIDeviceFamily" => [
    0 => 1
    1 => 2
  ]
  "UIRequiredDeviceCapabilities" => [
    0 => "arm64"
  ]
  "UISupportedInterfaceOrientations" => [
    0 => "UIInterfaceOrientationPortrait"
    1 => "UIInterfaceOrientationLandscapeLeft"
    2 => "UIInterfaceOrientationLandscapeRight"
  ]
  "UISupportedInterfaceOrientations~ipad" => [
    0 => "UIInterfaceOrientationPortrait"
    1 => "UIInterfaceOrientationPortraitUpsideDown"
    2 => "UIInterfaceOrientationLandscapeLeft"
    3 => "UIInterfaceOrientationLandscapeRight"
  ]
  "XSAppIconAssets" => "Assets.xcassets/appicon.appiconset"
}
$ # src/Templates/src/templates/maui-mobile/MauiApp1/MacCatalyst/Info.plist is also same result
```